### PR TITLE
Add ability to exit with custom error message

### DIFF
--- a/examples/custom_message.rs
+++ b/examples/custom_message.rs
@@ -1,0 +1,43 @@
+#![feature(try_trait)]
+use exit::ExitWithMessage as Exit;
+
+use std::env;
+use std::option;
+
+#[derive(Debug)]
+enum MyErr {
+    MissingArg,
+    ParseErrorUserNum,
+    ParseErrorGroupNum,
+}
+
+impl From<MyErr> for (i32, String) {
+    fn from(err: MyErr) -> Self {
+        match err {
+            MyErr::MissingArg => (2, String::from("An argument is missing")),
+            MyErr::ParseErrorUserNum => (3, String::from("Error parsing user number")),
+            MyErr::ParseErrorGroupNum => (4, String::from("Error parsing group number")),
+        }
+    }
+}
+
+impl From<option::NoneError> for MyErr {
+    fn from(_: option::NoneError) -> Self {
+        MyErr::MissingArg
+    }
+}
+
+// The aliased import allows using ExitWithMessage as Exit
+fn main() -> Exit<MyErr> {
+    let user_num_string : String = env::args().skip(1).next()?;
+    let group_num_string : String = env::args().skip(2).next()?;
+
+    let user_num : u32 = user_num_string.parse()
+        .map_err(|_| MyErr::ParseErrorUserNum)?;
+    let group_num : u32 = group_num_string.parse()
+        .map_err(|_| MyErr::ParseErrorGroupNum)?;
+
+    println!("Hello, user #{} from group #{}!", user_num, group_num);
+
+    Exit::Ok
+}


### PR DESCRIPTION
This adds the ability to specify a custom error message when exiting. 

It would be nice if `impl<T: Into<(i32, String)>> Termination for ExitWithMessage<T>` could be written in such a way to allow anything which `impl Display` rather than specifying a String type, but I'm not sure how to express that.

Even better would be a way to combine the `Exit` and `ExitWithMessage` types while allowing a user to optionally provide an error message. 