### PR TITLE
implement exit display for custom exit messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exit"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Josh Mcguigan"]
 edition = "2018"
 description = "Custom exit status codes with ? in main"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The goal of this crate was to provide a proof of concept and sample implementati
 
 ```rust
 #![feature(try_trait)]
-use exit::Exit;
+use exit::{Exit, ExitDisplay};
 
 use std::env;
 use std::option;
@@ -27,6 +27,14 @@ impl From<MyErr> for i32 {
             MyErr::ParseErrorUserNum => 3,
             MyErr::ParseErrorGroupNum => 4,
         }
+    }
+}
+
+// You can optionally implement ExitDisplay for your error type in order to print an error message
+// on exit
+impl ExitDisplay for MyErr {
+    fn display(&self) -> String {
+        format!("{:?}", self)
     }
 }
 

--- a/examples/from_error.rs
+++ b/examples/from_error.rs
@@ -5,7 +5,6 @@ use std::env;
 use core::option;
 use core::num;
 
-#[derive(Debug)]
 enum MyErr {
     MissingArg,
     ParseIntError,

--- a/examples/map_err.rs
+++ b/examples/map_err.rs
@@ -1,5 +1,5 @@
 #![feature(try_trait)]
-use exit::Exit;
+use exit::{Exit, ExitDisplay};
 
 use std::env;
 use std::option;
@@ -18,6 +18,14 @@ impl From<MyErr> for i32 {
             MyErr::ParseErrorUserNum => 3,
             MyErr::ParseErrorGroupNum => 4,
         }
+    }
+}
+
+// You can optionally implement ExitDisplay for your error type in order to print an error message
+// on exit
+impl ExitDisplay for MyErr {
+    fn display(&self) -> String {
+        format!("{:?}", self)
     }
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,5 @@
 use exit::Exit;
 
-#[derive(Debug)]
 enum MyErr {
     OneLessThanZero,
     OneEqualsTwo,


### PR DESCRIPTION
Allows user to derive a trait to customize the error message, or skip deriving the trait to disable error message printing. No longer requires the error type to impl debug.